### PR TITLE
Accessibility: Font icons are not read by screen readers

### DIFF
--- a/src/components/shared/Header.js
+++ b/src/components/shared/Header.js
@@ -18,19 +18,19 @@ const alwaysOptions = (
 	<>
 		<Nav.Item className='container m-2 github'>
 				<a href='https://github.com/amishizaki'>
-					<FontAwesomeIcon icon={ faSquareGithub } alt='GitHub icon' size='lg' className='nav-icon'/>
+					<FontAwesomeIcon icon={ faSquareGithub } title='GitHub icon' size='lg' className='nav-icon'/>
 				</a>
 				<p className='hide'>GitHub</p>
 		</Nav.Item>
 		<Nav.Item className='m-2 linkedin'>
 				<a href='https://www.linkedin.com/in/alina-ishizaki/' >
-					<FontAwesomeIcon icon={ faLinkedin } alt='LinkedIn icon' size='lg' className='nav-icon'/>
+					<FontAwesomeIcon icon={ faLinkedin } title='LinkedIn icon' size='lg' className='nav-icon'/>
 				</a>
 				<p className='hide'>LinkedIn</p>
 		</Nav.Item>
 		<Nav.Item className='m-2 resumeicon'>
 				<a href='https://docs.google.com/document/d/e/2PACX-1vQVuIbsm5-qUKNRsam4n9dkPUFlEpyXngtjXKVj_d9QcsqMjzRQrK-gyoNjpPqz_uID9dCf258TTOrE/pub' >
-					<FontAwesomeIcon icon={ faFileLines } alt='A file icon' size='lg' className='nav-icon'/>
+					<FontAwesomeIcon icon={ faFileLines } title='Resume' size='lg' className='nav-icon'/>
 				</a>
 				<p className='hide'>Resume</p>
 		</Nav.Item>


### PR DESCRIPTION
### Issue description
Items in the navbar are not read by screen readers, and cannot be focused using tab. Accessibility documentation for FontAwesome entities can be found [here.](https://fontawesome.com/docs/web/dig-deeper/accessibility)

### Possible reasons
* The icons may not have properly tagged accessible text.
* The span expanding/collapsing the menu may not expose accessible attributes to be activated.

### Solution in this PR
Per the [FontAwesome docs,](https://fontawesome.com/docs/web/dig-deeper/accessibility) I changed all 'alt' attributes on FontAwesome icons to 'title'. I did not test whether this fixes the problem.